### PR TITLE
[feat][한정빈] : input 박스 컴포넌트 구현

### DIFF
--- a/app/test-component/page.tsx
+++ b/app/test-component/page.tsx
@@ -7,7 +7,7 @@ import Button from '@/components/common/Button';
 import SearchBar from '@/components/common/SearchBar';
 import StarRating from '@/components/common/StarRating';
 import Slider from '@/components/common/Slider';
-import InputBox from '@/components/common/InputBox';
+import InputWithLabel from '@/components/common/InputWithLabel';
 
 const modalBoxStyle = {
   position: 'absolute',
@@ -105,7 +105,7 @@ export default function TestComponent() {
           </Box>
         </li>
         <li>
-          <InputBox
+          <InputWithLabel
             label="이메일"
             value={inputValue}
             onChange={handleInputChange}

--- a/app/test-component/page.tsx
+++ b/app/test-component/page.tsx
@@ -4,8 +4,8 @@ import {Box} from '@mui/material';
 import Modal from '@/components/common/modal';
 import ContentBox from '@/components/common/ContentBox';
 import Button from '@/components/common/Button';
-import SearchBar from '@/components/common/searchBar';
-import StarRating from '@/components/common/starRating';
+import SearchBar from '@/components/common/SearchBar';
+import StarRating from '@/components/common/StarRating';
 import Slider from '@/components/common/Slider';
 
 const modalBoxStyle = {

--- a/app/test-component/page.tsx
+++ b/app/test-component/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/common/Button';
 import SearchBar from '@/components/common/SearchBar';
 import StarRating from '@/components/common/StarRating';
 import Slider from '@/components/common/Slider';
+import InputBox from '@/components/common/InputBox';
 
 const modalBoxStyle = {
   position: 'absolute',
@@ -23,6 +24,8 @@ const modalBoxStyle = {
 export default function TestComponent() {
   const [modalStatus, setModalStatus] = useState<boolean>(false);
   const [searchResult, setSearchResult] = useState<string>('');
+  const [inputValue, setInputValue] = useState('');
+  const [emailError, setEmailError] = useState<string | undefined>('');
 
   const handleOpenModal = () => {
     setModalStatus(true);
@@ -35,6 +38,18 @@ export default function TestComponent() {
 
   const handleSliderChange = (e: React.SyntheticEvent | Event, value: number | number[]) => {
     console.log(`slider - ${value}`);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  const handleBlur = () => {
+    if (!inputValue) {
+      setEmailError('이메일을 입력하세요');
+    } else {
+      setEmailError('');
+    }
   };
 
   return (
@@ -88,6 +103,19 @@ export default function TestComponent() {
           <Box className="w-full h-100">
             <Slider style={{width: '30.688rem', height: '0.5rem', margin: 10}} defaultValue={50} min={0} max={100} onChange={handleSliderChange} />
           </Box>
+        </li>
+        <li>
+          <InputBox
+            label="이메일"
+            value={inputValue}
+            onChange={handleInputChange}
+            onBlur={handleBlur}
+            placeholder="이메일 입력"
+            type="email"
+            error={emailError}
+            wrapperClassName="gap-10pxr"
+            inputClassName="h-[42px] tablet:h-[48px] w-[303px] tablet:w-[400px]"
+          />
         </li>
       </ul>
     </>

--- a/components/common/InputBox.tsx
+++ b/components/common/InputBox.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+interface InputBoxProps {
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  type?: string;
+  error?: string;
+  wrapperClassName?: string;
+  inputClassName?: string;
+}
+
+export default function InputBox({
+  label,
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  type = 'text',
+  error,
+  wrapperClassName = '',
+  inputClassName = '',
+}: InputBoxProps) {
+  return (
+    <div className={`flex flex-col ${wrapperClassName}`}>
+      <label className="text-lg font-medium">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        className={`px-20pxr py-14pxr rounded-[12px] tablet:rounded-[16px] border border-gray-300 placeholder:text-gray-500  focus:outline-none ${inputClassName}`}
+      ></input>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+    </div>
+  );
+}

--- a/components/common/InputWithLabel.tsx
+++ b/components/common/InputWithLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface InputBoxProps {
+interface InputWithLabelProps {
   label: string;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -12,7 +12,7 @@ interface InputBoxProps {
   inputClassName?: string;
 }
 
-export default function InputBox({
+export default function InputWithLabel({
   label,
   value,
   onChange,
@@ -22,7 +22,7 @@ export default function InputBox({
   error,
   wrapperClassName = '',
   inputClassName = '',
-}: InputBoxProps) {
+}: InputWithLabelProps) {
   return (
     <div className={`flex flex-col ${wrapperClassName}`}>
       <label className="text-lg font-medium">{label}</label>

--- a/components/common/InputWithLabel.tsx
+++ b/components/common/InputWithLabel.tsx
@@ -1,38 +1,19 @@
-import React from 'react';
+import React, {InputHTMLAttributes} from 'react';
 
-interface InputWithLabelProps {
+interface InputWithLabelProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur?: () => void;
-  placeholder?: string;
-  type?: string;
   error?: string;
   wrapperClassName?: string;
   inputClassName?: string;
 }
 
-export default function InputWithLabel({
-  label,
-  value,
-  onChange,
-  onBlur,
-  placeholder,
-  type = 'text',
-  error,
-  wrapperClassName = '',
-  inputClassName = '',
-}: InputWithLabelProps) {
+export default function InputWithLabel({label, error, wrapperClassName = '', inputClassName = '', ...inputProps}: InputWithLabelProps) {
   return (
     <div className={`flex flex-col ${wrapperClassName}`}>
       <label className="text-lg font-medium">{label}</label>
       <input
-        type={type}
-        value={value}
-        onChange={onChange}
-        onBlur={onBlur}
-        placeholder={placeholder}
         className={`px-20pxr py-14pxr rounded-[12px] tablet:rounded-[16px] border border-gray-300 placeholder:text-gray-500  focus:outline-none ${inputClassName}`}
+        {...inputProps}
       ></input>
       {error && <p className="text-red-500 text-sm">{error}</p>}
     </div>

--- a/components/common/SearchBar.tsx
+++ b/components/common/SearchBar.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import {useState} from 'react';
-// import Image from 'next/image';
-import Search from './search';
+import Search from './Search';
 
 interface SearchBarProps {
   placeholder?: string;

--- a/components/common/StarRating.tsx
+++ b/components/common/StarRating.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Rating from '@mui/material/Rating';
 import {Box} from '@mui/material';
-import StarIcon from './starIcon';
+import StarIcon from './StarIcon';
 
 interface StarRatingProps {
   value: number;


### PR DESCRIPTION
## 📌 Related Issue
- Closed #8 

## 🧾 작업 사항
- input 박스 컴포넌트 작업했습니다

## 📚 리뷰 포인트
- 

## 💬 추가 설명
- 사용하는 부분이 로그인 회원가입, 와인 등록 폼인데 각각 스타일이 달라서(width, gap 등) 스타일 덧붙일 수 있도록 해두었습니다
<img width="328" alt="스크린샷 2024-12-19 오후 6 51 44" src="https://github.com/user-attachments/assets/8e5ec4da-3849-402b-b613-55118884a00b" />

focusout 하면 에러 메시지가 뜹니다
- 추후에 hook form 과 함께 사용한다면 value, onChange, onBlur, error 등을 받아서 넘겨주면 됩니다

- 12/20 멘토링 코드리뷰 반영하여 interface 확장, 파일명 변경했습니다